### PR TITLE
Handle current timestamp default value

### DIFF
--- a/Entity/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/Entity/Serializer/Normalizer/DateTimeNormalizer.php
@@ -66,6 +66,11 @@ class DateTimeNormalizer implements DateTimeNormalizerInterface
         $utcTimeZone = new \DateTimeZone('UTC');
 
         if ($hasTimeZone) {
+
+            if (strtoupper($value) === 'CURRENT_TIMESTAMP') {
+                $value = null;
+            }
+
             $value = new \DateTime(
                 $value,
                 $this->requestDateTimeResolver->getTimezone()


### PR DESCRIPTION
We use "CURRENT_TIMESTAMP" as datetime default value in some api fields. Handle it