### PR TITLE
Download filename between underscores

### DIFF
--- a/Symfony/Controller/DownloadAction.php
+++ b/Symfony/Controller/DownloadAction.php
@@ -122,11 +122,20 @@ class DownloadAction
 
         $disposition = $response->headers->makeDisposition(
             $forceDownload ? ResponseHeaderBag::DISPOSITION_ATTACHMENT : ResponseHeaderBag::DISPOSITION_INLINE,
-            $fileName
+            $this->sanitizeFileName($fileName)
         );
         $response->headers->set('Content-Disposition', $disposition);
         $response->headers->set('Content-Type', $mimeType ?: 'application/octet-stream');
 
         return $response;
+    }
+
+    private function sanitizeFileName(string $fileName): string
+    {
+        return str_replace(
+            ' ',
+            '_',
+            $fileName
+        );
     }
 }


### PR DESCRIPTION
Fixed problem with filenames with spaces added to the beginning and end of underscores when downloading.