### PR TITLE
Update default nullable optional parameters sign

### DIFF
--- a/Behat/Context/FeatureContext.php
+++ b/Behat/Context/FeatureContext.php
@@ -96,7 +96,7 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
     /**
      * @When I send a :method multipart request to :url with body:
      */
-    public function iSendAMultipartRequestTo($method, $url, PyStringNode $body = null, $files = [])
+    public function iSendAMultipartRequestTo($method, $url, ?PyStringNode $body = null, $files = [])
     {
         if ($body !== null) {
             $body = implode(

--- a/Core/Serializer/SerializerContextBuilder.php
+++ b/Core/Serializer/SerializerContextBuilder.php
@@ -20,7 +20,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
     /**
      * {@inheritdoc}
      */
-    public function createFromRequest(Request $request, bool $normalization, array $attributes = null): array
+    public function createFromRequest(Request $request, bool $normalization, ?array $attributes = null): array
     {
         $context = $this->decorated->createFromRequest(
             $request,
@@ -34,7 +34,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         );
     }
 
-    private function operationTypeOverwrite(array $context, array $attributes = null)
+    private function operationTypeOverwrite(array $context, ?array $attributes = null)
     {
         $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
 

--- a/Doctrine/Orm/Extension/DynamicLoadingExtension.php
+++ b/Doctrine/Orm/Extension/DynamicLoadingExtension.php
@@ -36,8 +36,8 @@ final class DynamicLoadingExtension implements QueryItemExtensionInterface, Quer
         PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory,
         PropertyMetadataFactoryInterface $propertyMetadataFactory,
         ResourceMetadataFactoryInterface $resourceMetadataFactory,
-        RequestStack $requestStack = null,
-        SerializerContextBuilderInterface $serializerContextBuilder = null
+        ?RequestStack $requestStack = null,
+        ?SerializerContextBuilderInterface $serializerContextBuilder = null
     ) {
         $this->propertyNameCollectionFactory = $propertyNameCollectionFactory;
         $this->propertyMetadataFactory = $propertyMetadataFactory;
@@ -54,7 +54,7 @@ final class DynamicLoadingExtension implements QueryItemExtensionInterface, Quer
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
         array $identifiers,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $options = [];
@@ -80,7 +80,7 @@ final class DynamicLoadingExtension implements QueryItemExtensionInterface, Quer
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null
+        ?string $operationName = null
     ) {
         $options = [];
 
@@ -129,18 +129,6 @@ final class DynamicLoadingExtension implements QueryItemExtensionInterface, Quer
 
     /**
      * Joins relations to eager load.
-     *
-     * @param QueryBuilder $queryBuilder
-     * @param QueryNameGeneratorInterface $queryNameGenerator
-     * @param string $resourceClass
-     * @param string $parentAlias
-     * @param array $propertyMetadataOptions
-     * @param array $context
-     * @param bool $wasLeftJoin if the relation containing the new one had a left join, we have to force the new one to left join too
-     * @param int $joinCount the number of joins
-     * @param int $currentDepth the current max depth
-     *
-     * @throws RuntimeException when the max number of joins has been reached
      */
     private function joinRelations(
         QueryBuilder $queryBuilder,
@@ -151,7 +139,7 @@ final class DynamicLoadingExtension implements QueryItemExtensionInterface, Quer
         array $context = [],
         bool $wasLeftJoin = false,
         int &$joinCount = 0,
-        int $currentDepth = null
+        ?int $currentDepth = null
     ) {
         if (is_null($currentDepth)) {
             $isCollection = isset($context['collection']) && $context['collection'] === 'collection';
@@ -259,7 +247,7 @@ final class DynamicLoadingExtension implements QueryItemExtensionInterface, Quer
                     continue;
                 }
 
-                $embedddedProperty = array_key_exists(  
+                $embedddedProperty = array_key_exists(
                     $property,
                     $targetClassMetadata->embeddedClasses
                 );

--- a/Doctrine/Orm/Extension/SecurityFilterExtension.php
+++ b/Doctrine/Orm/Extension/SecurityFilterExtension.php
@@ -30,7 +30,7 @@ class SecurityFilterExtension implements QueryCollectionExtensionInterface, Quer
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
         array $identifiers,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $dataAccessControl = $this->dataAccessControlParser->get();
@@ -51,7 +51,7 @@ class SecurityFilterExtension implements QueryCollectionExtensionInterface, Quer
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null
+        ?string $operationName = null
     ) {
         $dataAccessControl = $this->dataAccessControlParser->get();
 

--- a/Doctrine/Orm/Extension/UnpaginatedResultGeneratorExtension.php
+++ b/Doctrine/Orm/Extension/UnpaginatedResultGeneratorExtension.php
@@ -46,8 +46,8 @@ final class UnpaginatedResultGeneratorExtension implements ContextAwareQueryResu
     public function applyToCollection(
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
-        string $resourceClass = null,
-        string $operationName = null,
+        ?string $resourceClass = null,
+        ?string $operationName = null,
         array $context = []
     ) {
     }
@@ -55,7 +55,7 @@ final class UnpaginatedResultGeneratorExtension implements ContextAwareQueryResu
     /**
      * {@inheritdoc}
      */
-    public function supportsResult(string $resourceClass, string $operationName = null, array $context = []): bool
+    public function supportsResult(string $resourceClass, ?string $operationName = null, array $context = []): bool
     {
         $request = $this->requestStack->getCurrentRequest();
         if (null === $request) {
@@ -78,8 +78,8 @@ final class UnpaginatedResultGeneratorExtension implements ContextAwareQueryResu
      */
     public function getResult(
         QueryBuilder $queryBuilder,
-        string $resourceClass = null,
-        string $operationName = null,
+        ?string $resourceClass = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         ini_set('max_execution_time', '0');
@@ -131,7 +131,7 @@ final class UnpaginatedResultGeneratorExtension implements ContextAwareQueryResu
     private function isPaginationEnabled(
         Request $request,
         ResourceMetadata $resourceMetadata,
-        string $operationName = null
+        ?string $operationName = null
     ): bool {
         $enabled = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_enabled', $this->enabled, true);
         $clientEnabled = $resourceMetadata->getCollectionOperationAttribute($operationName, 'pagination_client_enabled', $this->clientEnabled, true);

--- a/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/Doctrine/Orm/Filter/BooleanFilter.php
@@ -23,9 +23,9 @@ class BooleanFilter extends BaseBooleanFilter
     public function __construct(
         ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
-        LoggerInterface $logger = null,
-        array $properties = null,
-        NameConverterInterface $nameConverter = null,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?NameConverterInterface $nameConverter,
         ResourceMetadataFactoryInterface $resourceMetadataFactory
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -58,7 +58,7 @@ class BooleanFilter extends BaseBooleanFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);

--- a/Doctrine/Orm/Filter/DateFilter.php
+++ b/Doctrine/Orm/Filter/DateFilter.php
@@ -26,9 +26,9 @@ class DateFilter extends BaseDateFilter
     public function __construct(
         ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
-        LoggerInterface $logger = null,
-        array $properties = null,
-        NameConverterInterface $nameConverter = null,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?NameConverterInterface $nameConverter,
         ResourceMetadataFactoryInterface $resourceMetadataFactory
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -62,7 +62,7 @@ class DateFilter extends BaseDateFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);
@@ -75,7 +75,7 @@ class DateFilter extends BaseDateFilter
      * @inherited
      * @see BaseDateFilter::addWhere
      */
-    protected function addWhere(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, string $operator, $value, string $nullManagement = null, $type = null)
+    protected function addWhere(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $field, string $operator, $value, ?string $nullManagement = null, $type = null)
     {
         if (is_array($value)) {
             foreach ($value as $key => $val) {

--- a/Doctrine/Orm/Filter/ExistsFilter.php
+++ b/Doctrine/Orm/Filter/ExistsFilter.php
@@ -24,10 +24,10 @@ class ExistsFilter extends BaseExistsFilter
         ManagerRegistry $managerRegistry,
         ResourceMetadataFactoryInterface $resourceMetadataFactory,
         ?RequestStack $requestStack,
-        LoggerInterface $logger = null,
-        array $properties = null,
+        ?LoggerInterface $logger = null,
+        ?array $properties = null,
         string $existsParameterName = self::QUERY_PARAMETER_KEY,
-        NameConverterInterface $nameConverter = null
+        ?NameConverterInterface $nameConverter = null
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         parent::__construct(
@@ -81,7 +81,7 @@ class ExistsFilter extends BaseExistsFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);

--- a/Doctrine/Orm/Filter/FilterTrait.php
+++ b/Doctrine/Orm/Filter/FilterTrait.php
@@ -11,7 +11,7 @@ trait FilterTrait
      */
     protected $resourceMetadataFactory;
 
-    public function setProperties(array $properties = null)
+    public function setProperties(?array $properties = null)
     {
         $this->properties = $properties;
     }

--- a/Doctrine/Orm/Filter/NotEqualFilter.php
+++ b/Doctrine/Orm/Filter/NotEqualFilter.php
@@ -22,9 +22,9 @@ final class NotEqualFilter extends AbstractContextAwareFilter
     public function __construct(
         ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
-        LoggerInterface $logger = null,
-        array $properties = null,
-        NameConverterInterface $nameConverter = null,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?NameConverterInterface $nameConverter,
         ResourceMetadataFactoryInterface $resourceMetadataFactory
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -44,7 +44,7 @@ final class NotEqualFilter extends AbstractContextAwareFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);
@@ -53,7 +53,7 @@ final class NotEqualFilter extends AbstractContextAwareFilter
         return parent::apply($queryBuilder, $queryNameGenerator, $resourceClass, $operationName, $context);
     }
 
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?string $operationName = null)
     {
         // otherwise filter is applied to order and page as well
         if (

--- a/Doctrine/Orm/Filter/NumericFilter.php
+++ b/Doctrine/Orm/Filter/NumericFilter.php
@@ -23,9 +23,9 @@ class NumericFilter extends BaseNumericFilter
     public function __construct(
         ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
-        LoggerInterface $logger = null,
-        array $properties = null,
-        NameConverterInterface $nameConverter = null,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?NameConverterInterface $nameConverter,
         ResourceMetadataFactoryInterface $resourceMetadataFactory
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -72,7 +72,7 @@ class NumericFilter extends BaseNumericFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);

--- a/Doctrine/Orm/Filter/OrderFilter.php
+++ b/Doctrine/Orm/Filter/OrderFilter.php
@@ -24,9 +24,9 @@ class OrderFilter extends BaseOrderFilter
         ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
         $orderParameterName,
-        LoggerInterface $logger = null,
-        array $properties = null,
-        NameConverterInterface $nameConverter = null,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?NameConverterInterface $nameConverter,
         ResourceMetadataFactoryInterface $resourceMetadataFactory
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -66,7 +66,7 @@ class OrderFilter extends BaseOrderFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);

--- a/Doctrine/Orm/Filter/RangeFilter.php
+++ b/Doctrine/Orm/Filter/RangeFilter.php
@@ -23,10 +23,10 @@ class RangeFilter extends BaseRangeFilter
     public function __construct(
         ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
-        LoggerInterface $logger = null,
-        array $properties = null,
+        ?LoggerInterface $logger,
+        ?array $properties,
         ResourceMetadataFactoryInterface $resourceMetadataFactory,
-        NameConverterInterface $nameConverter = null
+        ?NameConverterInterface $nameConverter = null
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
         parent::__construct(
@@ -58,7 +58,7 @@ class RangeFilter extends BaseRangeFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);

--- a/Doctrine/Orm/Filter/SearchFilter.php
+++ b/Doctrine/Orm/Filter/SearchFilter.php
@@ -41,11 +41,11 @@ class SearchFilter extends BaseSearchFilter
         ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
         IriConverterInterface $iriConverter,
-        PropertyAccessorInterface $propertyAccessor = null,
-        LoggerInterface $logger = null,
-        array $properties = null,
-        IdentifiersExtractorInterface $identifiersExtractor = null,
-        NameConverterInterface $nameConverter = null,
+        ?PropertyAccessorInterface $propertyAccessor,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?IdentifiersExtractorInterface $identifiersExtractor,
+        ?NameConverterInterface $nameConverter,
         ResourceMetadataFactoryInterface $resourceMetadataFactory
     ) {
         $this->resourceMetadataFactory = $resourceMetadataFactory;
@@ -176,7 +176,7 @@ class SearchFilter extends BaseSearchFilter
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null,
+        ?string $operationName = null,
         array $context = []
     ) {
         $metadata = $this->resourceMetadataFactory->create($resourceClass);

--- a/Doctrine/Orm/Filter/SearchFilterExact.php
+++ b/Doctrine/Orm/Filter/SearchFilterExact.php
@@ -27,11 +27,11 @@ class SearchFilterExact extends SearchFilter
         \Symfony\Bridge\Doctrine\ManagerRegistry $managerRegistry,
         ?RequestStack $requestStack,
         IriConverterInterface $iriConverter,
-        PropertyAccessorInterface $propertyAccessor = null,
-        LoggerInterface $logger = null,
-        array $properties = null,
-        IdentifiersExtractorInterface $identifiersExtractor = null,
-        NameConverterInterface $nameConverter = null,
+        ?PropertyAccessorInterface $propertyAccessor,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?IdentifiersExtractorInterface $identifiersExtractor,
+        ?NameConverterInterface $nameConverter,
         ResourceMetadataFactoryInterface $resourceMetadataFactory,
         private PropertyMetadataFactoryInterface $propertyMetadataFactory
     ) {
@@ -56,7 +56,7 @@ class SearchFilterExact extends SearchFilter
         return parent::getDescription($resourceClass, $addDefault);
     }
 
-    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?string $operationName = null, array $context = [])
     {
         $contextCopy = (new \ArrayObject($context))->getArrayCopy();
         foreach ($contextCopy['filters'] as $field => $filters) {
@@ -122,7 +122,7 @@ class SearchFilterExact extends SearchFilter
         $value, QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        string $operationName = null
+        ?string $operationName = null
     ) {
         $this->resourceClass = $resourceClass;
         return parent::filterProperty(...func_get_args());

--- a/Doctrine/Orm/Filter/SearchFilterStart.php
+++ b/Doctrine/Orm/Filter/SearchFilterStart.php
@@ -23,7 +23,7 @@ class SearchFilterStart extends SearchFilter
 {
     const SERVICE_NAME = 'ivoz.api.filter.search_start';
 
-    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?string $operationName = null, array $context = [])
     {
 
         $contextCopy = (new \ArrayObject($context))->getArrayCopy();

--- a/Entity/Metadata/Property/Factory/PropertyNameCollectionFactory.php
+++ b/Entity/Metadata/Property/Factory/PropertyNameCollectionFactory.php
@@ -30,7 +30,7 @@ class PropertyNameCollectionFactory implements PropertyNameCollectionFactoryInte
         PropertyMetadataFactoryInterface $propertyMetadataFactory,
         ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory,
         TokenStorageInterface $tokenStorage,
-        string $defaultRole = null
+        ?string $defaultRole = null
     ) {
         $this->propertyMetadataFactory = $propertyMetadataFactory;
         $this->tokenStorage = $tokenStorage;
@@ -43,10 +43,10 @@ class PropertyNameCollectionFactory implements PropertyNameCollectionFactoryInte
         }
 
         $this->dummyNormalizer = new class implements NormalizerInterface, SerializerInterface {
-            public function supportsNormalization($data, string $format = null) {
+            public function supportsNormalization($data, ?string $format = null) {
                 return true;
             }
-            public function normalize($object, string $format = null, array $context = []) { return null; }
+            public function normalize($object, ?string $format = null, array $context = []) { return null; }
             public function serialize($data, string $format, array $context = []) { return ''; }
             public function deserialize($data, string $type, string $format, array $context = []) { return null; }
         };

--- a/Entity/Serializer/Normalizer/EntityDenormalizer.php
+++ b/Entity/Serializer/Normalizer/EntityDenormalizer.php
@@ -62,7 +62,7 @@ class EntityDenormalizer implements DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, string $format = null)
+    public function supportsDenormalization($data, $type, ?string $format = null)
     {
         return class_exists($type . 'Dto');
     }
@@ -72,7 +72,7 @@ class EntityDenormalizer implements DenormalizerInterface
      *
      * @throws InvalidArgumentException
      */
-    public function denormalize($data, $class, string $format = null, array $context = [])
+    public function denormalize($data, $class, ?string $format = null, array $context = [])
     {
         $data = $this->denormalizeDateTimes($data, $class);
 
@@ -146,7 +146,7 @@ class EntityDenormalizer implements DenormalizerInterface
         return $response;
     }
 
-    private function denormalizeEntity(array $input, string $class, EntityInterface $entity = null, string $normalizationContext)
+    private function denormalizeEntity(array $input, string $class, ?EntityInterface $entity, string $normalizationContext)
     {
         $propertyNameCollection = $this->propertyNameCollectionFactory->create(
             $class,
@@ -274,7 +274,7 @@ class EntityDenormalizer implements DenormalizerInterface
      * @param DataTransferObjectInterface $dto
      * @return EntityInterface
      */
-    private function mapToEntity(string $class, EntityInterface $entity = null, DataTransferObjectInterface $dto): EntityInterface
+    private function mapToEntity(string $class, ?EntityInterface $entity, DataTransferObjectInterface $dto): EntityInterface
     {
         if ($entity) {
             $this->updateEntityFromDto->execute(

--- a/EventListener/RegisterCommandListener.php
+++ b/EventListener/RegisterCommandListener.php
@@ -77,8 +77,8 @@ final class RegisterCommandListener
 
     private function triggerEvent(
         array $params,
-        array $body = null,
-        EntityInterface $user = null
+        ?array $body = null,
+        ?EntityInterface $user = null
     ) {
 
         $resourceClass = $params['_api_resource_class'] ?? '';

--- a/Swagger/Metadata/Property/Factory/PropertyMetadataLinkFactory.php
+++ b/Swagger/Metadata/Property/Factory/PropertyMetadataLinkFactory.php
@@ -10,7 +10,7 @@ class PropertyMetadataLinkFactory implements PropertyMetadataFactoryInterface
 {
     private $decorated;
 
-    public function __construct(PropertyMetadataFactoryInterface $decorated = null)
+    public function __construct(?PropertyMetadataFactoryInterface $decorated = null)
     {
         $this->decorated = $decorated;
     }

--- a/Swagger/Metadata/Property/Factory/PropertyMetadataOverwriteFactory.php
+++ b/Swagger/Metadata/Property/Factory/PropertyMetadataOverwriteFactory.php
@@ -28,7 +28,7 @@ class PropertyMetadataOverwriteFactory implements PropertyMetadataFactoryInterfa
      * @param Reader $reader
      */
     public function __construct(
-        PropertyMetadataFactoryInterface $decorated = null,
+        ?PropertyMetadataFactoryInterface $decorated,
         Reader $reader
     ) {
         $this->decorated = $decorated;

--- a/Swagger/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
+++ b/Swagger/Metadata/Resource/Factory/ExtractorResourceMetadataFactory.php
@@ -41,7 +41,7 @@ class ExtractorResourceMetadataFactory implements ResourceMetadataFactoryInterfa
      *
      * @return ResourceMetadata
      */
-    private function handleNotFound(ResourceMetadata $parentPropertyMetadata = null, string $resourceClass): ResourceMetadata
+    private function handleNotFound(?ResourceMetadata $parentPropertyMetadata, string $resourceClass): ResourceMetadata
     {
         if (null !== $parentPropertyMetadata) {
             return $parentPropertyMetadata;

--- a/Swagger/Serializer/DocumentationNormalizer/BasePathDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/BasePathDecorator.php
@@ -39,7 +39,7 @@ class BasePathDecorator implements NormalizerInterface, CacheableSupportsMethodI
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -47,7 +47,7 @@ class BasePathDecorator implements NormalizerInterface, CacheableSupportsMethodI
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
         $response['basePath'] = $this->router->generate('api_base_path');

--- a/Swagger/Serializer/DocumentationNormalizer/CollectionResponseHeaderFixedDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/CollectionResponseHeaderFixedDecorator.php
@@ -31,7 +31,7 @@ class CollectionResponseHeaderFixedDecorator implements NormalizerInterface, Cac
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -39,7 +39,7 @@ class CollectionResponseHeaderFixedDecorator implements NormalizerInterface, Cac
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
 

--- a/Swagger/Serializer/DocumentationNormalizer/CustomParameterDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/CustomParameterDecorator.php
@@ -31,7 +31,7 @@ class CustomParameterDecorator implements NormalizerInterface, CacheableSupports
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -39,7 +39,7 @@ class CustomParameterDecorator implements NormalizerInterface, CacheableSupports
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
 

--- a/Swagger/Serializer/DocumentationNormalizer/DefinitionFixerDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/DefinitionFixerDecorator.php
@@ -39,7 +39,7 @@ class DefinitionFixerDecorator implements NormalizerInterface, CacheableSupports
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -47,7 +47,7 @@ class DefinitionFixerDecorator implements NormalizerInterface, CacheableSupports
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
         $resourceMapping = $this->getResourceMapping($object);

--- a/Swagger/Serializer/DocumentationNormalizer/MissingReferenceFixerDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/MissingReferenceFixerDecorator.php
@@ -38,7 +38,7 @@ class MissingReferenceFixerDecorator implements NormalizerInterface, CacheableSu
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -46,7 +46,7 @@ class MissingReferenceFixerDecorator implements NormalizerInterface, CacheableSu
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
         $response['definitions'] = $this->registerPendingDefinitions(
@@ -136,7 +136,7 @@ class MissingReferenceFixerDecorator implements NormalizerInterface, CacheableSu
      *
      * @return string
      */
-    private function getDefinition(\ArrayObject $definitions, ResourceMetadata $resourceMetadata, string $resourceClass, array $serializerContext = null): string
+    private function getDefinition(\ArrayObject $definitions, ResourceMetadata $resourceMetadata, string $resourceClass, ?array $serializerContext = null): string
     {
         $definitionKey = $resourceMetadata->getShortName();
         if (!isset($definitions[$definitionKey])) {
@@ -159,7 +159,7 @@ class MissingReferenceFixerDecorator implements NormalizerInterface, CacheableSu
      *
      * @return \ArrayObject
      */
-    private function getDefinitionSchema(string $resourceClass, ResourceMetadata $resourceMetadata, \ArrayObject $definitions, array $serializerContext = null): \ArrayObject
+    private function getDefinitionSchema(string $resourceClass, ResourceMetadata $resourceMetadata, \ArrayObject $definitions, ?array $serializerContext = null): \ArrayObject
     {
         $definitionSchema = ['type' => 'object'];
 
@@ -205,7 +205,7 @@ class MissingReferenceFixerDecorator implements NormalizerInterface, CacheableSu
      *
      * @return \ArrayObject
      */
-    private function getPropertySchema(PropertyMetadata $propertyMetadata, \ArrayObject $definitions, array $serializerContext = null): \ArrayObject
+    private function getPropertySchema(PropertyMetadata $propertyMetadata, \ArrayObject $definitions, ?array $serializerContext = null): \ArrayObject
     {
         $propertySchema = new \ArrayObject($propertyMetadata->getAttributes()['swagger_context'] ?? []);
 
@@ -249,7 +249,7 @@ class MissingReferenceFixerDecorator implements NormalizerInterface, CacheableSu
      *
      * @return array
      */
-    private function getType(string $type, bool $isCollection, string $className = null, bool $readableLink = null, \ArrayObject $definitions, array $serializerContext = null): array
+    private function getType(string $type, bool $isCollection, ?string $className = null, ?bool $readableLink = null, \ArrayObject $definitions, ?array $serializerContext = null): array
     {
         if ($isCollection) {
             return ['type' => 'array', 'items' => $this->getType($type, false, $className, $readableLink, $definitions, $serializerContext)];

--- a/Swagger/Serializer/DocumentationNormalizer/OrphanAttributeFixerDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/OrphanAttributeFixerDecorator.php
@@ -39,7 +39,7 @@ class OrphanAttributeFixerDecorator implements NormalizerInterface, CacheableSup
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -47,7 +47,7 @@ class OrphanAttributeFixerDecorator implements NormalizerInterface, CacheableSup
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
 

--- a/Swagger/Serializer/DocumentationNormalizer/ReferenceFixerDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/ReferenceFixerDecorator.php
@@ -32,7 +32,7 @@ class ReferenceFixerDecorator implements NormalizerInterface, CacheableSupportsM
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -40,7 +40,7 @@ class ReferenceFixerDecorator implements NormalizerInterface, CacheableSupportsM
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
         $response['definitions'] = $this->fixRelationReferences($response['definitions']);

--- a/Swagger/Serializer/DocumentationNormalizer/RequiredAttributeFixerDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/RequiredAttributeFixerDecorator.php
@@ -31,7 +31,7 @@ class RequiredAttributeFixerDecorator implements NormalizerInterface, CacheableS
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -39,7 +39,7 @@ class RequiredAttributeFixerDecorator implements NormalizerInterface, CacheableS
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
 

--- a/Swagger/Serializer/DocumentationNormalizer/SearchFilterDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/SearchFilterDecorator.php
@@ -49,7 +49,7 @@ class SearchFilterDecorator implements NormalizerInterface, CacheableSupportsMet
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -57,7 +57,7 @@ class SearchFilterDecorator implements NormalizerInterface, CacheableSupportsMet
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $resourceMapping = [];
         foreach ($object->getResourceNameCollection() as $resourceName) {

--- a/Swagger/Serializer/DocumentationNormalizer/TimezoneSelectorDecorator.php
+++ b/Swagger/Serializer/DocumentationNormalizer/TimezoneSelectorDecorator.php
@@ -36,7 +36,7 @@ class TimezoneSelectorDecorator implements NormalizerInterface, CacheableSupport
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -44,7 +44,7 @@ class TimezoneSelectorDecorator implements NormalizerInterface, CacheableSupport
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
         $this->definitions = $response['definitions'];

--- a/Swagger/Serializer/DocumentationNormalizer/UnusedDefinitionRemover.php
+++ b/Swagger/Serializer/DocumentationNormalizer/UnusedDefinitionRemover.php
@@ -31,7 +31,7 @@ class UnusedDefinitionRemover implements NormalizerInterface, CacheableSupportsM
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $this->decoratedNormalizer->supportsNormalization(...func_get_args());
     }
@@ -39,7 +39,7 @@ class UnusedDefinitionRemover implements NormalizerInterface, CacheableSupportsM
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         $response = $this->decoratedNormalizer->normalize(...func_get_args());
         $usedDefinitions = $this->getUsedDefinitions($response);


### PR DESCRIPTION
According to documentation, the format ClassName $paremeter = null will be deprecated in 8.4.0

More info at https://www.php.net/manual/en/functions.arguments.php