### PR TITLE
[CDL-155] Add IDE directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IDE directories
+.vscode
+.idea

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/ivoz-api.iml
+++ b/.idea/ivoz-api.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/ivoz-api.iml" filepath="$PROJECT_DIR$/.idea/ivoz-api.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
This pull request includes several changes to clean up the `.idea` directory by removing unnecessary configuration files. The most important changes are the removal of various `.idea` files related to project configuration and version control settings.

Cleanup of `.idea` directory:

* [`.idea/.gitignore`](diffhunk://#diff-21610973868a98feff98dd0460438a8a32cca1447bc8701537ec5048e0c5faebL1-L8): Removed default ignored files and directories related to IntelliJ IDEA.
* [`.idea/ivoz-api.iml`](diffhunk://#diff-95a5ee3bc0ab2b7a3b0530ff30f696e87b77d68c8f5d0da9cfe4bc88c291bb5fL1-L8): Removed the module configuration file for the `ivoz-api` module.
* [`.idea/modules.xml`](diffhunk://#diff-0aae258f1732eac2acd4fcdd1af6d0737b4ec8d233136c3ba7c40b6d49aeda50L1-L8): Removed the project modules configuration file.
* [`.idea/vcs.xml`](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aL1-L6): Removed the version control system configuration file.