### PR TITLE
CDL-219 collection filters for to-many associations

### DIFF
--- a/Doctrine/Orm/Filter/CollectionFilter.php
+++ b/Doctrine/Orm/Filter/CollectionFilter.php
@@ -1,0 +1,613 @@
+<?php
+
+namespace Ivoz\Api\Doctrine\Orm\Filter;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+/**
+ * Filters a collection by the contents of a to-many association.
+ *
+ * Api-platform generates no filters for to-many associations, so entities related
+ * through an intermediate entity (the usual N-M modelling in ivoz) could not be
+ * filtered at all. This filter fills that gap.
+ *
+ * It is declared per resource, mapping a logical name (usually the name of the
+ * property the frontend already displays) to the doctrine path it resolves to:
+ *
+ *     attributes:
+ *       collectionFilters:
+ *         licenceTypes:
+ *           path: 'licencesRelUsers.licenceType'
+ *           strategies: ['in', 'all', 'exists']
+ *
+ * Which exposes:
+ *
+ *     ?licenceTypes[]=1&licenceTypes[]=3   Rows related to 1 OR 3
+ *     ?licenceTypes[all]=1,3               Rows related to 1 AND 3
+ *     ?exists[licenceTypes]=false          Rows with no related row at all
+ *
+ * Every strategy is resolved with correlated EXISTS subqueries rather than joins,
+ * so no row multiplication is introduced and neither DISTINCT nor GROUP BY are
+ * needed, leaving ordering and pagination untouched.
+ */
+final class CollectionFilter extends AbstractContextAwareFilter
+{
+    use FilterTrait;
+
+    public const SERVICE_NAME = 'ivoz.api.filter.collection';
+
+    public const STRATEGY_IN = 'in';
+    public const STRATEGY_ALL = 'all';
+    public const STRATEGY_NONE = 'none';
+    public const STRATEGY_ONLY = 'only';
+    public const STRATEGY_EXISTS = 'exists';
+
+    public const STRATEGIES = [
+        self::STRATEGY_IN,
+        self::STRATEGY_ALL,
+        self::STRATEGY_NONE,
+        self::STRATEGY_ONLY,
+        self::STRATEGY_EXISTS,
+    ];
+
+    private const COMPARISON_IN = 'IN';
+    private const COMPARISON_NOT_IN = 'NOT IN';
+
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        ?RequestStack $requestStack,
+        ?LoggerInterface $logger,
+        ?array $properties,
+        ?NameConverterInterface $nameConverter,
+        ResourceMetadataFactoryInterface $resourceMetadataFactory
+    ) {
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+        parent::__construct(
+            $managerRegistry,
+            $requestStack,
+            $logger,
+            $properties,
+            $nameConverter
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?string $operationName = null,
+        array $context = []
+    ) {
+        $metadata = $this->resourceMetadataFactory->create($resourceClass);
+        $this->overrideProperties($metadata->getAttributes());
+
+        if (empty($this->properties)) {
+            return;
+        }
+
+        return parent::apply(
+            $queryBuilder,
+            $queryNameGenerator,
+            $resourceClass,
+            $operationName,
+            $context
+        );
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function filterProperty(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?string $operationName = null
+    ) {
+        // ?exists[<property>]=<bool> arrives keyed by the exists parameter itself
+        if ($property === self::STRATEGY_EXISTS) {
+            foreach ((array) $value as $field => $existsValue) {
+                $this->applyExists(
+                    (string) $field,
+                    $existsValue,
+                    $queryBuilder,
+                    $queryNameGenerator,
+                    $resourceClass
+                );
+            }
+
+            return;
+        }
+
+        $config = $this->properties[$property] ?? null;
+        if (!is_array($config)) {
+            return;
+        }
+
+        $enabled = $this->enabledStrategies($config);
+
+        // A request may carry several strategies for the same property, as in
+        // ?licenceTypes[all]=1&licenceTypes[none]=2: every one of them narrows
+        // the result down, so they are applied in conjunction
+        foreach ($this->parseValue($value) as [$strategy, $values]) {
+            if (!in_array($strategy, $enabled, true)) {
+                continue;
+            }
+
+            $this->applyStrategy(
+                $property,
+                $strategy,
+                $values,
+                $config,
+                $queryBuilder,
+                $queryNameGenerator,
+                $resourceClass
+            );
+        }
+    }
+
+    /**
+     * @param array<int, mixed>    $values
+     * @param array<string, mixed> $config
+     */
+    private function applyStrategy(
+        string $property,
+        string $strategy,
+        array $values,
+        array $config,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass
+    ): void {
+        if ($strategy === self::STRATEGY_EXISTS) {
+            $this->applyExists(
+                $property,
+                reset($values),
+                $queryBuilder,
+                $queryNameGenerator,
+                $resourceClass
+            );
+
+            return;
+        }
+
+        $values = array_values(array_filter($values, static function ($item): bool {
+            return $item !== '' && $item !== null;
+        }));
+
+        if (empty($values)) {
+            return;
+        }
+
+        $path = $config['path'];
+
+        if ($strategy === self::STRATEGY_NONE) {
+            // The negation of in: a single NOT EXISTS over the whole set
+            $this->forbidRelated(
+                $queryBuilder,
+                $queryNameGenerator,
+                $resourceClass,
+                $path,
+                $values
+            );
+
+            return;
+        }
+
+        if ($strategy === self::STRATEGY_IN) {
+            $this->requireRelated(
+                $queryBuilder,
+                $queryNameGenerator,
+                $resourceClass,
+                $path,
+                $values
+            );
+
+            return;
+        }
+
+        // all and only both demand every requested value to be present, one
+        // EXISTS each, and only additionally rules out anything else
+        foreach ($values as $item) {
+            $this->requireRelated(
+                $queryBuilder,
+                $queryNameGenerator,
+                $resourceClass,
+                $path,
+                [$item]
+            );
+        }
+
+        if ($strategy === self::STRATEGY_ONLY) {
+            $this->forbidUnrelated(
+                $queryBuilder,
+                $queryNameGenerator,
+                $resourceClass,
+                $path,
+                $values
+            );
+        }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function applyExists(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass
+    ): void {
+        $config = $this->properties[$property] ?? null;
+        if (!is_array($config)) {
+            return;
+        }
+
+        if (!in_array(self::STRATEGY_EXISTS, $this->enabledStrategies($config), true)) {
+            return;
+        }
+
+        $exists = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($exists === null) {
+            return;
+        }
+
+        $this->requireAnyRelated(
+            $queryBuilder,
+            $queryNameGenerator,
+            $resourceClass,
+            $config['path'],
+            $exists
+        );
+    }
+
+    /**
+     * At least one related row matches the given values
+     *
+     * @param array<int, mixed> $values
+     */
+    private function requireRelated(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $path,
+        array $values
+    ): void {
+        $this->addRelatedSubQuery(
+            $queryBuilder,
+            $queryNameGenerator,
+            $resourceClass,
+            $path,
+            $values,
+            self::COMPARISON_IN,
+            false
+        );
+    }
+
+    /**
+     * No related row matches the given values
+     *
+     * @param array<int, mixed> $values
+     */
+    private function forbidRelated(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $path,
+        array $values
+    ): void {
+        $this->addRelatedSubQuery(
+            $queryBuilder,
+            $queryNameGenerator,
+            $resourceClass,
+            $path,
+            $values,
+            self::COMPARISON_IN,
+            true
+        );
+    }
+
+    /**
+     * No related row falls outside the given values
+     *
+     * @param array<int, mixed> $values
+     */
+    private function forbidUnrelated(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $path,
+        array $values
+    ): void {
+        $this->addRelatedSubQuery(
+            $queryBuilder,
+            $queryNameGenerator,
+            $resourceClass,
+            $path,
+            $values,
+            self::COMPARISON_NOT_IN,
+            true
+        );
+    }
+
+    /**
+     * There is at least one related row, whatever its value, or none at all
+     */
+    private function requireAnyRelated(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $path,
+        bool $required
+    ): void {
+        $this->addRelatedSubQuery(
+            $queryBuilder,
+            $queryNameGenerator,
+            $resourceClass,
+            $path,
+            null,
+            self::COMPARISON_IN,
+            !$required
+        );
+    }
+
+    /**
+     * Correlated EXISTS subquery over the to-many association.
+     *
+     * Callers should go through the named wrappers above rather than spelling
+     * out the comparison and the negation here.
+     *
+     * @param array<int, mixed>|null $values null restricts nothing, matching any related row
+     */
+    private function addRelatedSubQuery(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $path,
+        ?array $values,
+        string $comparison,
+        bool $negate
+    ): void {
+        [$associationName, $field] = $this->splitPath($path);
+
+        $entityManager = $queryBuilder->getEntityManager();
+        $association = $entityManager
+            ->getClassMetadata($resourceClass)
+            ->getAssociationMapping($associationName);
+
+        $mappedBy = $association['mappedBy'] ?? null;
+        if (!$mappedBy) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Collection filter path "%s" must start with an association mapped by the '
+                    . 'related entity (one-to-many or the inverse side of many-to-many), "%s" is not.',
+                    $path,
+                    $associationName
+                )
+            );
+        }
+
+        $alias = $queryNameGenerator->generateJoinAlias($associationName);
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+
+        $subQuery = $entityManager
+            ->createQueryBuilder()
+            ->select('1')
+            ->from($association['targetEntity'], $alias)
+            ->andWhere(sprintf('%s.%s = %s', $alias, $mappedBy, $rootAlias));
+
+        if ($values !== null) {
+            $parameterName = $queryNameGenerator->generateParameterName($associationName);
+            $subQuery->andWhere(
+                sprintf('%s.%s %s (:%s)', $alias, $field, $comparison, $parameterName)
+            );
+            $queryBuilder->setParameter($parameterName, $values);
+        }
+
+        $expression = $queryBuilder->expr()->exists($subQuery->getDQL());
+
+        $queryBuilder->andWhere(
+            $negate
+                ? $queryBuilder->expr()->not($expression)
+                : $expression
+        );
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function splitPath(string $path): array
+    {
+        $segments = explode('.', $path);
+
+        if (count($segments) !== 2) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Collection filter path "%s" must be "<association>.<field>", '
+                    . 'deeper paths are not supported.',
+                    $path
+                )
+            );
+        }
+
+        return [$segments[0], $segments[1]];
+    }
+
+    /**
+     * Resolves the request value into every strategy it requests, along with the
+     * values each one takes. More than one may be present, as in
+     * ?licenceTypes[all]=1&licenceTypes[none]=2.
+     *
+     * @param mixed $value
+     *
+     * @return array<int, array{0: string, 1: array<int, mixed>}>
+     */
+    private function parseValue($value): array
+    {
+        if (!is_array($value)) {
+            return [[self::STRATEGY_IN, [$value]]];
+        }
+
+        $response = [];
+        $bareValues = [];
+
+        foreach ($value as $key => $item) {
+            // ?property[]=a&property[]=b comes in numerically indexed
+            if (is_numeric($key)) {
+                $bareValues[] = $item;
+                continue;
+            }
+
+            if (!in_array($key, self::STRATEGIES, true)) {
+                continue;
+            }
+
+            $response[] = [(string) $key, $this->normalizeValues($item)];
+        }
+
+        if (!empty($bareValues)) {
+            $response[] = [self::STRATEGY_IN, $this->splitValues($bareValues)];
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array<int, mixed>
+     */
+    private function normalizeValues($value): array
+    {
+        if (is_array($value)) {
+            return $this->splitValues(array_values($value));
+        }
+
+        // A single multi valued form control feeds every strategy the same way,
+        // as a comma separated list
+        return array_map('trim', explode(',', (string) $value));
+    }
+
+    /**
+     * @param array<int, mixed> $values
+     *
+     * @return array<int, mixed>
+     */
+    private function splitValues(array $values): array
+    {
+        $response = [];
+        foreach ($values as $value) {
+            if (!is_string($value) || !str_contains($value, ',')) {
+                $response[] = $value;
+                continue;
+            }
+
+            foreach (explode(',', $value) as $item) {
+                $response[] = trim($item);
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return string[]
+     */
+    private function enabledStrategies(array $config): array
+    {
+        /** @var string[] $strategies */
+        $strategies = $config['strategies'] ?? self::STRATEGIES;
+
+        return $strategies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        $metadata = $this->resourceMetadataFactory->create($resourceClass);
+        $this->overrideProperties($metadata->getAttributes());
+
+        if (empty($this->properties)) {
+            return [];
+        }
+
+        $description = [];
+        foreach ($this->properties as $property => $config) {
+            if (!is_array($config)) {
+                continue;
+            }
+
+            $strategies = $this->enabledStrategies($config);
+
+            if (in_array(self::STRATEGY_IN, $strategies, true)) {
+                foreach ([$property, $property . '[]'] as $parameterName) {
+                    $description[$parameterName] = [
+                        'property' => $property,
+                        'type' => Type::BUILTIN_TYPE_STRING,
+                        'required' => false,
+                        'strategy' => self::STRATEGY_IN,
+                    ];
+                }
+            }
+
+            $setDescriptions = [
+                self::STRATEGY_ALL => 'Comma separated values, all of them must be present',
+                self::STRATEGY_NONE => 'Comma separated values, none of them may be present',
+                self::STRATEGY_ONLY => 'Comma separated values, exactly them and nothing else',
+            ];
+
+            foreach ($setDescriptions as $strategy => $strategyDescription) {
+                if (!in_array($strategy, $strategies, true)) {
+                    continue;
+                }
+
+                $description[$property . '[' . $strategy . ']'] = [
+                    'property' => $property,
+                    'type' => Type::BUILTIN_TYPE_STRING,
+                    'required' => false,
+                    'strategy' => $strategy,
+                    'description' => $strategyDescription,
+                ];
+            }
+
+            if (in_array(self::STRATEGY_EXISTS, $strategies, true)) {
+                // Both spellings: clients send exists[<property>], while the operator is
+                // only offered by the UI when advertised as <property>[exists]
+                $parameterNames = [
+                    self::STRATEGY_EXISTS . '[' . $property . ']',
+                    $property . '[' . self::STRATEGY_EXISTS . ']',
+                ];
+
+                foreach ($parameterNames as $parameterName) {
+                    $description[$parameterName] = [
+                        'property' => $property,
+                        'type' => Type::BUILTIN_TYPE_BOOL,
+                        'required' => false,
+                        'strategy' => self::STRATEGY_EXISTS,
+                    ];
+                }
+            }
+        }
+
+        return $description;
+    }
+}

--- a/Swagger/Metadata/Resource/ResourceMetadata/FilterMetadataFactory.php
+++ b/Swagger/Metadata/Resource/ResourceMetadata/FilterMetadataFactory.php
@@ -8,6 +8,7 @@ use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Ivoz\Api\Doctrine\Orm\Filter\BooleanFilter;
+use Ivoz\Api\Doctrine\Orm\Filter\CollectionFilter;
 use Ivoz\Api\Doctrine\Orm\Filter\DateFilter;
 use Ivoz\Api\Doctrine\Orm\Filter\ExistsFilter;
 use Ivoz\Api\Doctrine\Orm\Filter\NotEqualFilter;
@@ -63,6 +64,12 @@ class FilterMetadataFactory implements ResourceMetadataFactoryInterface
 
         $attributes = $resourceMetadata->getAttributes();
         $filters = $this->getEntityFilters($resourceClass, $resourceMetadata);
+
+        $collectionFilters = $this->getCollectionFilters($resourceClass, $attributes);
+        if (!empty($collectionFilters)) {
+            $filters[CollectionFilter::SERVICE_NAME] = $collectionFilters;
+        }
+
         if (!empty($filters)) {
             $attributes['filters'] = array_keys($filters);
             $attributes['filters'][] = 'ivoz.api.filter.property_filter';
@@ -70,6 +77,201 @@ class FilterMetadataFactory implements ResourceMetadataFactoryInterface
         }
 
         return $resourceMetadata->withAttributes($attributes);
+    }
+
+    /**
+     * Reads the per-resource `collectionFilters` declaration, which maps a logical
+     * filter name to the to-many doctrine path it resolves to.
+     *
+     * @param array<string, mixed>|null $attributes
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function getCollectionFilters(string $resourceClass, ?array $attributes): array
+    {
+        $declaration = $attributes['collectionFilters'] ?? null;
+        if (!is_array($declaration)) {
+            return [];
+        }
+
+        $response = [];
+        foreach ($declaration as $name => $config) {
+            if (!is_array($config) || !isset($config['path'])) {
+                throw new \DomainException(
+                    sprintf(
+                        'Collection filter "%s" of %s must declare a "path".',
+                        $name,
+                        $resourceClass
+                    )
+                );
+            }
+
+            $this->assertToManyPath($resourceClass, (string) $name, (string) $config['path']);
+
+            $strategies = $config['strategies'] ?? CollectionFilter::STRATEGIES;
+            $unknown = array_diff($strategies, CollectionFilter::STRATEGIES);
+            if (!empty($unknown)) {
+                throw new \DomainException(
+                    sprintf(
+                        'Collection filter "%s" of %s declares unknown strategies: %s. Valid ones are: %s.',
+                        $name,
+                        $resourceClass,
+                        implode(', ', $unknown),
+                        implode(', ', CollectionFilter::STRATEGIES)
+                    )
+                );
+            }
+
+            if (in_array(CollectionFilter::STRATEGY_ONLY, $strategies, true)) {
+                $this->assertNotNullableTarget(
+                    $resourceClass,
+                    (string) $name,
+                    (string) $config['path']
+                );
+            }
+
+            $response[$name] = [
+                'path' => $config['path'],
+                'strategies' => array_values($strategies),
+            ];
+        }
+
+        return $response;
+    }
+
+    /**
+     * The `only` strategy rules out extra rows with `NOT IN`, and a NULL never
+     * matches `NOT IN`, so a nullable target would let rows carrying NULL slip
+     * through unnoticed and report a wider set as an exact match.
+     */
+    private function assertNotNullableTarget(string $resourceClass, string $name, string $path): void
+    {
+        $manager = $this->managerRegistry->getManagerForClass($resourceClass);
+        if (!$manager) {
+            return;
+        }
+
+        [$associationName, $field] = explode('.', $path);
+
+        /** @var ClassMetadata $metadata */
+        $metadata = $manager->getClassMetadata($resourceClass);
+        $association = $metadata->getAssociationMapping($associationName);
+
+        /** @var ClassMetadata $targetMetadata */
+        $targetMetadata = $manager->getClassMetadata($association['targetEntity']);
+
+        if ($targetMetadata->hasAssociation($field)) {
+            $mapping = $targetMetadata->getAssociationMapping($field);
+            $nullable = $mapping['joinColumns'][0]['nullable'] ?? true;
+        } else {
+            $mapping = $targetMetadata->getFieldMapping($field);
+            $nullable = $mapping['nullable'] ?? false;
+        }
+
+        if (!$nullable) {
+            return;
+        }
+
+        throw new \DomainException(
+            sprintf(
+                'Collection filter "%s" of %s declares the "%s" strategy over path "%s", but '
+                . '"%s" is nullable. Rows holding NULL there could not be told apart from '
+                . 'absent ones, so an exact match cannot be guaranteed.',
+                $name,
+                $resourceClass,
+                CollectionFilter::STRATEGY_ONLY,
+                $path,
+                $field
+            )
+        );
+    }
+
+    /**
+     * Fails fast on a mistyped path, so it surfaces on cache warmup instead of on
+     * the first request that happens to use the filter.
+     */
+    private function assertToManyPath(string $resourceClass, string $name, string $path): void
+    {
+        $segments = explode('.', $path);
+        if (count($segments) !== 2) {
+            throw new \DomainException(
+                sprintf(
+                    'Collection filter "%s" of %s declares path "%s", expected "<association>.<field>".',
+                    $name,
+                    $resourceClass,
+                    $path
+                )
+            );
+        }
+
+        [$associationName, $field] = $segments;
+
+        $manager = $this->managerRegistry->getManagerForClass($resourceClass);
+        if (!$manager) {
+            return;
+        }
+
+        /** @var ClassMetadata $metadata */
+        $metadata = $manager->getClassMetadata($resourceClass);
+
+        if (!$metadata->hasAssociation($associationName)) {
+            throw new \DomainException(
+                sprintf(
+                    'Collection filter "%s" of %s declares path "%s", but "%s" is not an association.',
+                    $name,
+                    $resourceClass,
+                    $path,
+                    $associationName
+                )
+            );
+        }
+
+        $association = $metadata->getAssociationMapping($associationName);
+        $isToMany = in_array(
+            $association['type'],
+            [ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY],
+            true
+        );
+
+        if (!$isToMany) {
+            throw new \DomainException(
+                sprintf(
+                    'Collection filter "%s" of %s declares path "%s", but "%s" is not a to-many '
+                    . 'association. Regular associations are already filterable.',
+                    $name,
+                    $resourceClass,
+                    $path,
+                    $associationName
+                )
+            );
+        }
+
+        if (empty($association['mappedBy'])) {
+            throw new \DomainException(
+                sprintf(
+                    'Collection filter "%s" of %s declares path "%s", but "%s" is not mapped by '
+                    . 'the related entity. Only the inverse side of a to-many association is supported.',
+                    $name,
+                    $resourceClass,
+                    $path,
+                    $associationName
+                )
+            );
+        }
+
+        $targetMetadata = $manager->getClassMetadata($association['targetEntity']);
+        if (!$targetMetadata->hasField($field) && !$targetMetadata->hasAssociation($field)) {
+            throw new \DomainException(
+                sprintf(
+                    'Collection filter "%s" of %s declares path "%s", but "%s" has no "%s" property.',
+                    $name,
+                    $resourceClass,
+                    $path,
+                    $association['targetEntity'],
+                    $field
+                )
+            );
+        }
     }
 
     private function getEntityFilters(string $resourceClass, ResourceMetadata $resourceMetadata)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,11 @@ parameters:
         -
             message: "#^Deprecated in PHP 8\\.1\\: Required parameter \\$resourceMetadataFactory follows optional parameter \\$nameConverter\\.$#"
             count: 1
+            path: Doctrine/Orm/Filter/CollectionFilter.php
+
+        -
+            message: "#^Deprecated in PHP 8\\.1\\: Required parameter \\$resourceMetadataFactory follows optional parameter \\$nameConverter\\.$#"
+            count: 1
             path: Doctrine/Orm/Filter/DateFilter.php
 
         -


### PR DESCRIPTION
## Problem

Api-platform generates no filters for to-many associations, and the metadata factory drops them explicitly: the `default` branch of `FilterMetadataFactory::getEntityFilters()` only handles scalars and `MANY_TO_ONE`.

The consequence is that in **no** application can a collection be filtered by an entity related through an intermediate one, which is how we usually model N-M relations. It surfaced in APS-956 (users and licences) but that will not be the last case.

## Approach

A new `CollectionFilter`, declared per resource. Each resource maps a logical name to the doctrine path it resolves to:

```yaml
attributes:
  collectionFilters:
    licenceTypes:
      path: 'licencesRelUsers.licenceType'
      strategies: ['in', 'all', 'none', 'only', 'exists']
```

Declaring them beats deriving them from every association automatically for two reasons: the parameter is named after the property the frontend already displays, so ivoz-ui needs to know nothing about doctrine paths, and the spec does not fill up with the cartesian product of the relations.

| Parameter | Meaning |
| --- | --- |
| `?prop[]=1&prop[]=3` | related to any of them |
| `?prop[all]=1,3` | related to all of them |
| `?prop[none]=1,3` | related to none of them |
| `?prop[only]=1,3` | related to exactly them and nothing else |
| `?exists[prop]=false` | not related to anything |

## Notes for the reviewer

**Correlated EXISTS subqueries rather than joins.** A join over a to-many association multiplies rows, and fixing that with `DISTINCT` breaks `ORDER BY` over non selected fields and hurts pagination. `EXISTS` introduces no multiplication, needs neither `DISTINCT` nor `GROUP BY`, and leaves ordering and pagination untouched. That also ruled out the obvious `HAVING COUNT(*) = N` formulation for `only`.

**Declarations are validated while metadata is built.** A mistyped path, an association that is not to-many, or an unknown strategy fail on cache warmup with an explicit message instead of on the first request that happens to use the filter.

**`only` rejects nullable targets.** It rules out extra rows with `NOT IN`, and a NULL never matches `NOT IN`, so a row holding NULL would slip through and report a wider set as an exact match.

**Several strategies combine on the same property.** `?prop[all]=1&prop[none]=2` applies both in conjunction.

## Known limitations

Only the inverse side of the association (the one declaring `mappedBy`) and two segment paths `association.field` are supported. Both are validated and reported; widen them when a case asks for it.

## Verification

phpstan level 5 clean. Functionally exercised from APS-956: 279 behat scenarios green, covering each strategy, the contrast between them over the same values, and the combinations.

Jira: CDL-219

🤖 Generated with [Claude Code](https://claude.com/claude-code)